### PR TITLE
Fix team menu css in home screen in responsive mode

### DIFF
--- a/css/responsive.css
+++ b/css/responsive.css
@@ -149,10 +149,24 @@
     border-bottom: 4px solid transparent;
     border-top: 4px solid #fff;
   }
+  .header-res-container .header--dropdown-wrap:hover .header--nav-link:before {
+    border-bottom: 4px solid transparent;
+    border-top: 4px solid #fff;
+  }
   .header--dropdown-wrap {
     width: 100%;
   }
   .header-dark .header--dropdown {
+    position: relative;
+    transform: translate(0,0);
+    left: 0;
+    top: 0;
+    box-shadow: none;
+    width: 100%;
+    border-radius: 0;
+    background: rgba(255, 255, 255, 0.15);
+  }
+  .header-res-container .header--dropdown {
     position: relative;
     transform: translate(0,0);
     left: 0;

--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
 
 <body>
 
-  <div class="header-container"></div>
+  <div class="header-container header-res-container"></div>
 
   <div class="home-hero-container"></div>
   <div class="home-research-container"></div>


### PR DESCRIPTION
Fix team menu css in home screen in responsive mode -
by adding css class **header-res-container** which has no styling except behaving (hover,...) exactly the same as **header-dark** class. And adding this **header-res-container** to index.html will implement the hover effect similar to publication.html

### Demo
![fix_home_team_css](https://user-images.githubusercontent.com/35439830/181908659-5cc867ef-993a-4366-8768-2c5cde50277a.gif)

